### PR TITLE
Ydj week2

### DIFF
--- a/src/main/java/week2/Algorithm11724.java
+++ b/src/main/java/week2/Algorithm11724.java
@@ -1,0 +1,53 @@
+package week2;
+
+import java.io.BufferedReader;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Algorithm11724 {
+
+    static int[][] graph;
+    static boolean[] visited;
+    static int nodeCnt;
+    static int cnt;
+
+    public static void main(String[] args) throws Exception {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+
+        StringTokenizer st = new StringTokenizer(br.readLine());
+        nodeCnt = Integer.parseInt(st.nextToken());
+        int edgeCnt = Integer.parseInt(st.nextToken());
+
+        graph = new int[nodeCnt + 1][nodeCnt + 1];
+        visited = new boolean[nodeCnt + 1];
+
+        for (int i = 0; i < edgeCnt; i++) {
+            st = new StringTokenizer(br.readLine());
+            int from = Integer.parseInt(st.nextToken());
+            int to = Integer.parseInt(st.nextToken());
+
+            graph[from][to] = 1;
+            graph[to][from] = 1;
+        }
+
+        cnt = 0;
+        for (int i = 1; i <= nodeCnt; i++) {
+            if (!visited[i]) {
+                dfs(i);
+                cnt++;
+            }
+        }
+
+        System.out.println(cnt);
+    }
+
+    static void dfs(int currentNode) {
+        visited[currentNode] = true;
+
+        for (int i = 1; i <= nodeCnt; i++) {
+            if (graph[currentNode][i] == 1 && !visited[i]) {
+                dfs(i);
+            }
+        }
+    }
+}

--- a/src/main/java/week2/Algorithm2583.java
+++ b/src/main/java/week2/Algorithm2583.java
@@ -1,0 +1,75 @@
+package week2;
+
+import java.util.*;
+
+public class Algorithm2583 {
+    static int M, N, K;
+    static int[][] grid;
+    static boolean[][] visited;
+    static final int[][] DIRECTIONS = {
+            {-1, 0}, {1, 0}, {0, -1}, {0, 1}
+    };
+
+    static int dfs(int x, int y) {
+        Stack<int[]> stack = new Stack<>();
+        stack.push(new int[]{x, y});
+        visited[y][x] = true;
+        int areaSize = 1;
+
+        while (!stack.isEmpty()) {
+            int[] current = stack.pop();
+            int cx = current[0], cy = current[1];
+
+            for (int i = 0; i < 4; i++) {
+                int nx = cx + DIRECTIONS[i][0], ny = cy + DIRECTIONS[i][1];
+
+                if (nx >= 0 && nx < N && ny >= 0 && ny < M && !visited[ny][nx] && grid[ny][nx] == 0) {
+                    visited[ny][nx] = true;
+                    stack.push(new int[]{nx, ny});
+                    areaSize++;
+                }
+            }
+        }
+        return areaSize;
+    }
+
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+
+        M = sc.nextInt();
+        N = sc.nextInt();
+        K = sc.nextInt();
+
+        grid = new int[M][N];
+        visited = new boolean[M][N];
+
+        for (int i = 0; i < K; i++) {
+            int x1 = sc.nextInt();
+            int y1 = sc.nextInt();
+            int x2 = sc.nextInt();
+            int y2 = sc.nextInt();
+
+            for (int y = y1; y < y2; y++) {
+                for (int x = x1; x < x2; x++) {
+                    grid[y][x] = 1;
+                }
+            }
+        }
+
+        List<Integer> areas = new ArrayList<>();
+
+        for (int y = 0; y < M; y++) {
+            for (int x = 0; x < N; x++) {
+                if (!visited[y][x] && grid[y][x] == 0) {
+                    areas.add(dfs(x, y));
+                }
+            }
+        }
+
+        Collections.sort(areas);
+        System.out.println(areas.size());
+        for (int area : areas) {
+            System.out.print(area + " ");
+        }
+    }
+}

--- a/src/main/java/week2/Algorithm4963.java
+++ b/src/main/java/week2/Algorithm4963.java
@@ -1,0 +1,73 @@
+package week2;
+
+import java.util.Scanner;
+
+public class Algorithm4963 {
+    static final int LAND = 1;
+    static final int SEA = 0;
+
+    static int[][] map;
+    static boolean[][] visited;
+    static int w, h;
+
+    static final int[][] DIRECTIONS = {
+            // 상하좌우
+            {-1, 0}, {1, 0}, {0, -1}, {0, 1},
+            // 대각선
+            {-1, -1}, {-1, 1}, {1, -1}, {1, 1}
+    };
+
+    public static void main(String[] args) {
+        try (Scanner sc = new Scanner(System.in)) {
+            while (true) {
+                w = sc.nextInt();
+                h = sc.nextInt();
+
+                if (w == 0 && h == 0) break;
+
+                map = new int[h][w];
+                visited = new boolean[h][w];
+
+                for (int i = 0; i < h; i++) {
+                    for (int j = 0; j < w; j++) {
+                        map[i][j] = sc.nextInt();
+                    }
+                }
+
+                System.out.println(cntIsland());
+            }
+        }
+    }
+
+    static int cntIsland() {
+        int cnt = 0;
+
+        for (int y = 0; y < h; y++) {
+            for (int x = 0; x < w; x++) {
+                if (map[y][x] == LAND && !visited[y][x]) {
+                    dfs(x, y);
+                    cnt++;
+                }
+            }
+        }
+
+        return cnt;
+    }
+
+    static void dfs(int x, int y) {
+        visited[y][x] = true;
+
+        for (int[] dir : DIRECTIONS) {
+            int nx = x + dir[0];
+            int ny = y + dir[1];
+
+            if (isInBounds(nx, ny) && map[ny][nx] == LAND && !visited[ny][nx]) {
+                dfs(nx, ny);
+            }
+        }
+    }
+
+    static boolean isInBounds(int x, int y) {
+        return x >= 0 && y >= 0 && x < w && y < h;
+    }
+}

--- a/src/main/java/week3/Algorithm13549.java
+++ b/src/main/java/week3/Algorithm13549.java
@@ -1,0 +1,65 @@
+package week3;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.ArrayDeque;
+import java.util.Arrays;
+import java.util.Deque;
+import java.util.StringTokenizer;
+
+/**
+ * 수빈이는 동생과 숨바꼭질을 하고 있다. 수빈이는 현재 점 N(0 ≤ N ≤ 100,000)에 있고, 동생은 점 K(0 ≤ K ≤ 100,000)에 있다. 수빈이는 걷거나 순간이동을 할 수 있다. 만약, 수빈이의 위치가 X일 때 걷는다면 1초 후에 X-1 또는 X+1로 이동하게 된다. 순간이동을 하는 경우에는 0초 후에 2*X의 위치로 이동하게 된다.
+ *
+ * 수빈이와 동생의 위치가 주어졌을 때, 수빈이가 동생을 찾을 수 있는 가장 빠른 시간이 몇 초 후인지 구하는 프로그램을 작성하시오.
+ *
+ * 첫 번째 줄에 수빈이가 있는 위치 N과 동생이 있는 위치 K가 주어진다. N과 K는 정수이다.
+ *
+ * 수빈이가 동생을 찾는 가장 빠른 시간을 출력한다.*/
+public class Algorithm13549 {
+    static final int MAX = 100_001;
+
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        StringTokenizer st = new StringTokenizer(br.readLine());
+
+        int s = Integer.parseInt(st.nextToken());
+        int e = Integer.parseInt(st.nextToken());
+
+        int[] dist = new int[MAX];
+        Arrays.fill(dist, -1);
+
+        Deque<Integer> dq = new ArrayDeque<>();
+        dq.offer(s);
+        dist[s] = 0;
+
+        while (!dq.isEmpty()) {
+            int cur = dq.poll();
+
+            if (cur == e) break;
+
+            // 순간이동 (0초)
+            int nx = cur * 2;
+            if (nx < MAX && dist[nx] == -1) {
+                dist[nx] = dist[cur];
+                dq.offerFirst(nx);
+            }
+
+            // 걷기 (-1)
+            nx = cur - 1;
+            if (nx >= 0 && dist[nx] == -1) {
+                dist[nx] = dist[cur] + 1;
+                dq.offerLast(nx);
+            }
+
+            // 걷기 (+1)
+            nx = cur + 1;
+            if (nx < MAX && dist[nx] == -1) {
+                dist[nx] = dist[cur] + 1;
+                dq.offerLast(nx);
+            }
+        }
+
+        System.out.println(dist[e]);
+    }
+}

--- a/src/main/java/week3/Algorithm16953.java
+++ b/src/main/java/week3/Algorithm16953.java
@@ -1,0 +1,41 @@
+package week3;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+/**
+ * 정수 A를 B로 바꾸려고 한다. 가능한 연산은 다음과 같은 두 가지이다.
+
+ * 2를 곱한다.
+ * 1을 수의 가장 오른쪽에 추가한다.
+ * A를 B로 바꾸는데 필요한 연산의 최솟값을 구해보자.
+ *
+ * 첫째 줄에 A, B (1 ≤ A < B ≤ 109)가 주어진다.
+ *
+ * A를 B로 바꾸는데 필요한 연산의 최솟값에 1을 더한 값을 출력한다. 만들 수 없는 경우에는 -1을 출력한다.
+ * */
+
+public class Algorithm16953 {
+    public static void main(String[] args) {
+        Scanner sc = new Scanner(System.in);
+        long a = sc.nextLong();
+        long b = sc.nextLong();
+        System.out.println(rsolve(a, b));
+    }
+
+    static int rsolve(long a, long b) {
+        int t = 1;
+        while (b > a) {
+            if (b % 10 == 1) {
+                b /= 10;
+            } else if (b % 2 == 0) {
+                b /= 2;
+            } else {
+                return -1;
+            }
+            t++;
+        }
+        return b == a ? t : -1;
+    }
+}


### PR DESCRIPTION
## 섬의 개수 - Algorithm4963

1. **문제 해결**
    
    이 문제는 2차원 배열 내에서 연결된 영역의 개수를 세는 문제입니다. 8방향 연결을 고려해야 하므로 일반적인 4방향 탐색에서 방향 배열을 조금 확장해야 합니다. 
    
2. **풀이 과정**
    - [ ]  입력을 여러 테스트 케이스로 받는다.
    - [ ]  테스트 케이스 하나마다 2차원 배열을 만들고, 섬의 개수를 0으로 초기화한다.
    - [ ]  2차원 배열을 순회하면서 1이면서 아직 방문하지 않은 위치를 찾는다.
    - [ ]  해당 위치에서 DFS를 실행하여 연결된 모든 1을 방문 처리한다.
    - [ ]  DFS가 끝날 때마다 섬의 개수를 1 증가시킨다.
    - [ ]  각 테스트 케이스마다 섬의 개수를 출력한다.

## 연결 요소의 개수 - Algorithm11724

1. 문제 해결
각 격자의 칸을 **노드**로 보고, 인접한 칸들을 **간선**으로 연결하여 분리된 영역을 찾을 수 있습니다.
2. 풀아 과정
    - [ ]  M, N, K 값을 받아온 후 K개의 직사각형 정보를 받습니다.
    - [ ]  M×N 크기의 이차원 배열을 만들고, 직사각형 부분을 방문 불가 영역(1)으로 표시합니다. 나머지 부분은 방문 가능한 영역(0)으로 표시합니다.
    - [ ]  그리드에서 아직 방문하지 않은 0을 발견하면 그곳에서 DFS 또는 BFS를 시작하여 연결된 영역을 모두 방문합니다. 이를 각 영역의 크기를 계산하여 저장합니다.
    - [ ]  찾은 영역의 크기를 오름차순으로 정렬하고 출력합니다.
3. 시간 복잡도
    - 그리드 크기는 최대 `100×100`이고, 직사각형의 개수 `K`는 최대 100개입니다.
    - 각 칸을 한 번만 방문하므로 DFS 탐색은 `O(M * N)` 시간 복잡도를 가집니다.
    - 전체적으로 입력을 받는 시간, DFS 탐색, 정렬을 포함하여 총 시간 복잡도는 `O(M * N + K + P log P)` (`P`는 분리된 영역의 개수)입니다.

## 영역 구하기 - Algorithm2583

1. **문제 해결**
    
    M×N 크기의 이차원 배열을 생성하고 직사각형 영역을 1로 표시합니다. 직사각형의 좌표에 해당하는 영역을 방문 불가 영역으로 설정합니다. 
    
2. **풀이 과정**
    - [ ]  M, N, K 값을 받아온 후 K개의 직사각형 정보를 받습니다.
    - [ ]  M×N 크기의 이차원 배열을 만들고, 직사각형 부분을 방문 불가 영역(1)으로 표시합니다. 나머지 부분은 방문 가능한 영역(0)으로 표시합니다.
    - [ ]  그리드에서 아직 방문하지 않은 0을 발견하면 그곳에서 DFS 또는 BFS를 시작하여 연결된 영역을 모두 방문합니다. 이를 각 영역의 크기를 계산하여 저장합니다.
    - [ ]  분리된 영역의 개수와 각 영역의 크기를 오름차순으로 정렬하여 출력합니다.