### PR TITLE
2주차 알고리즘 문제 풀이

### DIFF
--- a/src/main/java/org/example/BOJ11724.java
+++ b/src/main/java/org/example/BOJ11724.java
@@ -1,0 +1,69 @@
+package org.example;
+
+import java.util.ArrayList;
+import java.util.Scanner;
+
+public class BOJ11724 {
+	// 몇개의 그래프가 나오는지 알아내면 됨
+	// 방향이 없는 그래프임을 유의
+
+	static ArrayList<Integer>[] graph;
+	static boolean[] visited;
+
+	public static void main(String[] args) {
+		// 방문을 기록할 배열을 초기화
+		Scanner scanner = new Scanner(System.in);
+
+		int n = scanner.nextInt();
+		int m = scanner.nextInt();
+
+		// 인접 리스트의 인덱스 요소 초기화
+		graph = new ArrayList[n + 1];
+
+		// 방문 배열 초기화, 초기값 false
+		visited = new boolean[n + 1];
+
+		// 간선 수 만큼 빈 인접 리스트 생성
+		// 노드는 1부터 시작하므로 반복문으로 초기화도 1부터 n+1까지
+		for (int i = 1; i < n + 1; i++) {
+			graph[i] = new ArrayList<>();
+		}
+
+		for (int i = 0; i < m; i++) {
+			int u = scanner.nextInt();
+			int v = scanner.nextInt();
+
+			// 방향이 없으므로 양쪽 인접리스트에 다 추가
+			graph[u].add(v);
+			graph[v].add(u);
+		}
+
+		int dfsCount = 0;
+
+		// 방문 배열 순회하면서 dfs를 실행
+		for (int i = 1; i < n + 1; i++) {
+			if(!visited[i]) {
+				dfsCount++;
+				dfs(i);
+			}
+		}
+
+		System.out.println(dfsCount);
+	}
+	static void dfs(int node) {
+		// 현재 노드의 방문 배열 값이 true이면 재귀 탈출
+		if(visited[node]) {
+			return;
+		}
+
+		// 현재 노드의 방문 배열 값이 false면 true로 변경
+		visited[node] = true;
+
+		// 인접 리스트를 보고 다음 탐색 진행
+		for (int nextNode : graph[node]) {
+			if(!visited[nextNode]) {
+				dfs(nextNode);
+			}
+		}
+	}
+}

--- a/src/main/java/org/example/BOJ2583.java
+++ b/src/main/java/org/example/BOJ2583.java
@@ -1,0 +1,78 @@
+package org.example;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Scanner;
+
+public class BOJ2583 {
+	static boolean[][] visited;
+	static int[] dx = {0,0,-1,1};
+	static int[] dy = {-1,1,0,0};
+	static int area;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+
+		int m = sc.nextInt();
+		int n = sc.nextInt();
+		int k = sc.nextInt();
+
+		visited = new boolean[m][n];
+
+		for (int i = 0; i < k; i++) {
+			int startX = sc.nextInt();
+			int startY = m - sc.nextInt();
+			int endX = sc.nextInt();
+			int endY = m - sc.nextInt();
+
+			// 직사각형의 영역을 true로 처리
+			for (int j = endY; j < startY; j++) {
+				for (int l = startX; l < endX; l++) {
+					visited[j][l] = true;
+				}
+			}
+		}
+
+		int count = 0;
+		List<Integer> areas = new ArrayList<>();
+
+		// 직사각형이 존재하지 않는 영역에서만 DFS를 호출하고 횟수를 카운트
+		for (int i = 0; i < m; i++) {
+			for (int j = 0; j < n; j++) {
+				if(!visited[i][j]) {
+					count++;
+					area = 0;
+					dfs(j,i,m,n);
+					areas.add(area);
+				}
+			}
+		}
+
+		System.out.println(count);
+
+		// 순서대로 출력하기 위해 정렬
+		Collections.sort(areas);
+		areas.forEach(x -> System.out.print(x + " "));
+	}
+
+	static void dfs(int x, int y, int m, int n) {
+		// 현재 방문한 칸을 true로 변경하고 넓이에 1더하기
+		visited[y][x] = true;
+		area++;
+
+		// 상, 하, 좌, 우를 탐색하고 아직 탐색되지 않은 좌표에서만 재귀 호출
+		for(int i = 0; i<4; i++){
+			int newX = x + dx[i];
+			int newY = y + dy[i];
+
+			if (newX < 0 || newY < 0 || newX >= n || newY >= m) {
+				continue;
+			}
+
+			if(!visited[newY][newX]) {
+				dfs(newX, newY, m, n);
+			}
+		}
+	}
+}

--- a/src/main/java/org/example/BOJ4963.java
+++ b/src/main/java/org/example/BOJ4963.java
@@ -1,0 +1,71 @@
+package org.example;
+
+import java.util.Scanner;
+
+public class BOJ4963 {
+	static int[][] map;
+	static boolean[][] visited;
+	// 이동할 경로 8방향에 대한 dx, dy를 미리 선언
+	static int[] dx = {-1, -1, -1, 0, 0, 1, 1, 1};
+	static int[] dy = {-1, 0, 1, -1, 1, -1, 0, 1};
+
+	public static void main(String[] args) {
+		Scanner scanner = new Scanner(System.in);
+
+		while (true) {
+			int w = scanner.nextInt();
+			int h = scanner.nextInt();
+
+			if (w == 0 && h == 0)
+				break;
+
+			map = new int[h][w];
+			visited = new boolean[h][w];
+
+			for (int i = 0; i < h; i++) {
+				for (int j = 0; j < w; j++) {
+					map[i][j] = scanner.nextInt();
+				}
+			}
+
+			int result = 0;
+
+			for (int y = 0; y < h; y++) {
+				for (int x = 0; x < w; x++) {
+					// 이미 방문했거나 바다인 경우 dfs를 호출하지 않고 넘어감
+					if (!visited[y][x] && map[y][x] == 1) {
+						result++;
+						dfs(x, y, w, h);
+					}
+				}
+			}
+
+			System.out.println(result);
+		}
+	}
+
+	static void dfs(int x, int y, int w, int h) {
+		// 이미 방문한 곳이면 재귀 탈출
+		if (visited[y][x]) {
+			return;
+		}
+
+		visited[y][x] = true;
+
+		// 8방향 모두를 순회하며 재귀 호출
+		for (int i = 0; i < 8; i++) {
+			int newX = x + dx[i];
+			int newY = y + dy[i];
+
+			// 지정된 범위를 넘어가면 재귀호출 생략
+			if (newX < 0 || newY < 0 || newX >= w || newY >= h) {
+				continue;
+			}
+
+			// 방문하지 않은 곳이고 땅인 경우에만 재귀 호출
+			if (!visited[newY][newX] && map[newY][newX] == 1) {
+				dfs(newX, newY, w, h);
+			}
+		}
+	}
+}


### PR DESCRIPTION
## ✅ 섬의 개수(4963)

### 🤔 문제 확인

시간 제한 1초, 지도의 크기가 50*50이므로 시간복잡도 크게 상관 없음 2차원 배열을 이용한 DFS로 해결

대각선의 경우도 이어져 있는 땅으로 취급하므로 하나의 탐색 지점당 8가지의 이동경로가 발생

### 📝 풀이 방법

이동 방향에 대한 dx, dy를 미리 배열에 저장하고 탐색마다 해당 배열을 순회하며 탐색을 진행

탐색을 이미 한 지점인지 뿐만 아니라 바다인지 아닌지도 고려하여 DFS를 진행

DFS를 위한 재귀 호출 과정에서도 아직 탐색이 진행되지 않는 땅에서만 재귀를 호출하며 DFS호출 횟수를 카운트

최종적으로 최종적으로 DFS가 호출된 만큼 섬의 갯수가 발생

---

## ✅ 연결요소의 개수(11724)

### 🤔 문제 확인

시간 제한 3초, 정점의 수는 최대 1000, 간선의 수는 최대 499500 이므로 인접 리스트를 이용한 DFS로 해결해야함

### 📝 풀이 방법

ArrayList의 배열을 생성하여 인접리스트를 구현, 방향이 없는 그래프이므로 인접 리스트를 초기화 하는 과정에서 한 간선당 두 번의 초기화 과정이 필요

인접 리스트를 이용한 DFS이므로 해당 노드의 탐색 여부를 저장할 배열이 별도로 필요

탐색을 진행한 노드는 방문 여부를 true로 변경하고 다음 노드로 넘어가며 DFS를 진행하며 DFS가 호출된 횟수를 카운트

최종적으로 DFS가 호출된 만큼 연결요소가 발생

---

## ✅ 영역 구하기(2583)

### 🤔 문제 확인

시간 제한 1초, 주어진 데이터가 모두 100이하의 값이므로 시간복잡도 O(n^3)까지는 허용

2차원 배열을 이용한 DFS를 이용하면 약 O(n^3)의 시간복잡도로 해결 가능

### 📝 풀이 방법

주어진 사각형 범위 안에서 직사각형이 그려진 영역을 제외한 나머지 부분을 DFS로 탐색

탐색 과정에서 상, 하, 좌, 우로만 이동하며 탐색을 진행하며, 탐색을 한 번 할 때마다 넓이를 카운트

최종적으로 DFS가 호출된 만큼 빈 영역이 발생하며, 빈 영역 하나당 넓이를 게산하여 리스트에 저장 후 정렬하여 출력