### PR TITLE
3주차 알고리즘 문제 풀이

### DIFF
--- a/src/main/java/org/example/BOJ1260.java
+++ b/src/main/java/org/example/BOJ1260.java
@@ -1,0 +1,79 @@
+package org.example;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class BOJ1260 {
+	static ArrayList<Integer>[] graph;
+	static boolean[] visited;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		int m = sc.nextInt();
+		int v = sc.nextInt();
+
+		visited = new boolean[n + 1];
+		graph = new ArrayList[n + 1];
+
+		for (int i = 1; i < n + 1; i++) {
+			graph[i] = new ArrayList<>();
+		}
+
+		// 인접리스트 그래프 초기화
+		for (int i = 1; i <= m; i++) {
+			int start = sc.nextInt();
+			int end = sc.nextInt();
+
+			graph[start].add(end);
+			graph[end].add(start);
+		}
+
+		// 작은 값부터 탐색을 진행하기 위해 정렬 필요
+		for (int i = 1; i < n + 1; i++) {
+			Collections.sort(graph[i]);
+		}
+
+		dfs(v);
+		visited = new boolean[n + 1];
+		System.out.println();
+		bfs(v);
+
+	}
+
+	static void dfs(int v) {
+		if(visited[v]) {
+			return;
+		}
+
+		visited[v] = true;
+		System.out.print(v + " ");
+
+		for(int node : graph[v]) {
+			if(!visited[node]) {
+				dfs(node);
+			}
+		}
+	}
+
+	static void bfs(int v) {
+		Queue<Integer> queue = new LinkedList<>();
+		queue.add(v);
+		visited[v] = true;
+
+		while(!queue.isEmpty()) {
+			int currentNode = queue.poll();
+			for(int i : graph[currentNode]) {
+				if(!visited[i]) {
+					queue.add(i);
+					visited[i] = true;
+				}
+
+			}
+			System.out.print(currentNode+" ");
+		}
+	}
+}

--- a/src/main/java/org/example/BOJ13549.java
+++ b/src/main/java/org/example/BOJ13549.java
@@ -1,0 +1,59 @@
+package org.example;
+
+import java.util.Arrays;
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class BOJ13549 {
+	/*
+	 * bfs를 이용하며 도착지에서의 time을 카운트해야함
+	 * 이동할 수 있는 경로는 순간이동 *2, +1, -1
+	 * visited으로 이미 탐색된 경로의 탐색을 제한할 경우 최소 이동 경로를 찾는 과정이 제한됨
+	 * visited 대신 시간을 기록하고 최소 시간으로 갱신, bfs를 끝까지 수행
+	 */
+	static int[] time;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+
+		int n = sc.nextInt();
+		int k = sc.nextInt();
+
+		time = new int[100001];
+
+		// 최솟값 비교를 위해 배열의 모든 원소를 가장 큰 값인 100000으로 초기화
+		Arrays.fill(time, 100000);
+
+		// 걸린 시간 계산을 위해 시작점의 시간을 0으로 변경
+		time[n] = 0;
+		bfs(n);
+
+		System.out.println(time[k]);
+	}
+
+	static void bfs(int n) {
+		Queue<int[]> queue = new LinkedList<>();
+		queue.add(new int[] {n, 0});
+
+		while (!queue.isEmpty()) {
+			int[] current = queue.poll();
+			int currentPosition = current[0];
+			int currentTime = current[1];
+
+			// 주어진 범위 안이고 현재 탐색 경로의 시간이 기존 값보다 작으면 큐에 넣고 탐색을 진행, 시간 수정
+			if (currentPosition * 2 <= 100000 && time[currentPosition * 2] > currentTime) {
+				queue.offer(new int[] {currentPosition * 2, currentTime});
+				time[currentPosition * 2] = currentTime;
+			}
+			if (currentPosition + 1 <= 100000 && time[currentPosition + 1] > currentTime + 1) {
+				queue.offer(new int[] {currentPosition + 1, currentTime + 1});
+				time[currentPosition + 1] = currentTime + 1;
+			}
+			if (currentPosition - 1 >= 0 && time[currentPosition - 1] > currentTime + 1) {
+				queue.offer(new int[] {currentPosition - 1, currentTime + 1});
+				time[currentPosition - 1] = currentTime + 1;
+			}
+		}
+	}
+}

--- a/src/main/java/org/example/BOJ16953.java
+++ b/src/main/java/org/example/BOJ16953.java
@@ -1,0 +1,42 @@
+package org.example;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class BOJ16953 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+
+		long a = sc.nextInt();
+		long b = sc.nextInt();
+
+		long result = bfs(a, b);
+
+		System.out.println(result);
+	}
+
+	static long bfs(long a, long b) {
+		Queue<long[]> queue = new LinkedList<>();
+		queue.add(new long[] {a, 1});
+
+		while (!queue.isEmpty()) {
+			long[] current = queue.poll();
+			long currentPosition = current[0];
+			long currentCount = current[1];
+
+			if (currentPosition == b) {
+				return currentCount;
+			}
+
+			// 13549와 달리 연산 과정에서 현재보다 작은 수가 되는 경우가 없으므로 b까지만 연산을 수행하고 count를 반환
+			if (currentPosition * 10 + 1 <= b) {
+				queue.offer(new long[] {currentPosition * 10 + 1, currentCount + 1});
+			}
+			if (currentPosition * 2 <= b) {
+				queue.offer(new long[] {currentPosition * 2, currentCount + 1});
+			}
+		}
+		return -1;
+	}
+}

--- a/src/main/java/org/example/BOJ2178.java
+++ b/src/main/java/org/example/BOJ2178.java
@@ -1,0 +1,61 @@
+package org.example;
+
+import java.util.LinkedList;
+import java.util.Queue;
+import java.util.Scanner;
+
+public class BOJ2178 {
+	static int[] dy = {-1, 1, 0, 0};
+	static int[] dx = {0, 0, -1, 1};
+	static int[][] maze;
+	static boolean[][] visited;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+
+		int n = sc.nextInt();
+		int m = sc.nextInt();
+		sc.nextLine(); // 개행문자 소비 -> bufferedReader사용하면 안 써도 됨
+
+		maze = new int[n][m];
+		visited = new boolean[n][m];
+
+		for (int i = 0; i < n; i++) {
+			String line = sc.nextLine();
+			String[] numbers = line.split("");
+
+			for (int j = 0; j < m; j++) {
+				maze[i][j] = Integer.parseInt(numbers[j]);
+			}
+		}
+		bfs(0, 0, n, m);
+
+		System.out.println(maze[n - 1][m - 1]);
+	}
+
+	static void bfs(int x, int y, int n, int m) {
+		Queue<int[]> queue = new LinkedList<>();
+
+		queue.add(new int[] {x, y});
+		visited[x][y] = true;
+
+		while (!queue.isEmpty()) {
+			int[] currentVisited = queue.poll();
+
+			for (int i = 0; i < 4; i++) {
+				int newX = currentVisited[0] + dx[i];
+				int newY = currentVisited[1] + dy[i];
+
+				if (newX < 0 || newY < 0 || newX >= n || newY >= m) {
+					continue;
+				}
+
+				if (!visited[newX][newY] && maze[newX][newY] != 0) {
+					visited[newX][newY] = true;
+					maze[newX][newY] = maze[currentVisited[0]][currentVisited[1]] + 1;
+					queue.add(new int[] {newX, newY});
+				}
+			}
+		}
+	}
+}


### PR DESCRIPTION
## ✅ A→B(16953)

### 🤔 문제 확인

시간 제한 2초, 주어진 데이터의 크기가 1,000,000,000까지 이므로 배열을 순회하지 않고 BFS로 경로를 탐색, 입력값에 대한 변수 타입을 long으로 지정

### 📝 풀이 방법

연산 전과 후의 차이가 큰 '1을 수의 가장 오른쪽에 추가'에 대한 연산을 '2 곱하기'연산보다 우선으로 진행

연산 진행 과정에서 숫자가 작아지는 경우가 존재하지 않으므로 A에 연산을 진행한 결과가 B가 되었을 때 탐색 종료

BFS를 통해 A가 B에 도달했을 때, 가장 최소 연산으로 도달하는 경우이므로 이때의 연산 횟수를 반환

---

## ✅ 숨바꼭질 3(13549)

### 🤔 문제 확인

시간 제한 2초, 주어진 데이터의 크기가 100,000까지 이므로 배열을 순회하지 않고 BFS로 경로를 탐색하며 최소 시간 계산

### 📝 풀이 방법

BFS를 이용하여 경로를 탐색하면서 도착지에서의 소요 시간을 측정

탐색 과정에서 이동 후에 뒤로 돌아갈 수 있기 때문에 이미 탐색이 진행된 지점에서의 탐색이 허용되어야함

따라서 각 지점까지의 소요시간을 배열에 저장하고 목표 지점에 도달했을 때의 시간과 기존 시간을 비교하여 최솟값을 탐색

각 지점에서의 소요 시간이 기존 탐색에서의 소요시간보다 작은 경우에만 해당 지점을 탐색하기 위해 큐에 삽입

모든 경우를 탐색 한 뒤에 목표 지점의 소요시간을 출력

---

## ✅ 미로 탐색(2178)

### 🤔 문제 확인

시간 제한 1초, 주어진 데이터가 모두 100이하의 값이므로 시간복잡도 O(n^3)까지는 허용

2차원 배열을 이용한 BFS를 이용하면 약 O(n^3)의 시간복잡도로 해결 가능

### 📝 풀이 방법

이동 방향에 대한 dx, dy를 미리 배열에 저장하고 탐색마다 해당 배열을 순회하며 탐색을 진행

미로에 대한 입력값이 공백으로 구분되지 않으므로 split을 통해 2차원 배열로 변환

2차원 배열에서 1로 표시된 부분에 대한 BFS를 진행하며 해당 칸에 이동한 거리를 저장

최종적으로 목표 지점에서 카운트된 이동 거리가 최소 이동 거리

---

## ✅ DFS와 BFS(1260)

### 🤔 문제 확인

시간 제한 2초, 주어진 데이터는 정점의 개수1,000이고, 간선의 개수 10,000이므로 인접 리스트를 이용한 DFS와 BFS를 사용

### 풀이 방법

인접 리스트로 간선에 대한 정보를 그래프로 구현하고, 작은 수 부터 탐색이 진행되도록 각 인접 리스트마다 정렬을 진행

양방향 그래프 이므로 인접 리스트를 초기화 하는 과정에서 한 간선당 두 번의 초기화 과정이 필요

DFS와 BFS를 모두 시행해야 하므로 DFS수행 후 visited배열의 원소들을 다시 false로 초기화

재귀를 이용하여 DFS를 구현, 큐를 이용하여 BFS를 구현

DFS에서는 재귀 호출마다, BFS에서는 큐에서의 삭제가 발생할 때마다 간선의 정보를 출력