### PR TITLE
4주차 알고리즘

### DIFF
--- a/src/main/java/org/example/week4/Algorithm11726.java
+++ b/src/main/java/org/example/week4/Algorithm11726.java
@@ -1,0 +1,32 @@
+package org.example.week4;
+
+import java.util.Scanner;
+
+public class Algorithm11726 {
+        private static final int MOD = 10007;
+
+        public static void main(String[] args) {
+            Scanner sc = new Scanner(System.in);
+            int n = sc.nextInt();
+
+            // 기저 사례
+            if (n == 1) {
+                System.out.println(1);
+                return;
+            }
+
+            // 최소 메모리 사용: 변수 3개로 점화식 구현
+            int prev2 = 1; // dp[0]
+            int prev1 = 1; // dp[1]
+            int curr = 0;
+
+            for (int i = 2; i <= n; i++) {
+                curr = (prev1 + prev2) % MOD;
+                prev2 = prev1;
+                prev1 = curr;
+            }
+
+            System.out.println(curr); // 최종 정답: dp[n]
+        }
+}
+

--- a/src/main/java/org/example/week4/Algorithm15486.java
+++ b/src/main/java/org/example/week4/Algorithm15486.java
@@ -1,0 +1,36 @@
+package org.example.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+import java.util.StringTokenizer;
+
+public class Algorithm15486 {
+    public static void main(String[] args) throws IOException {
+        final BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        final int n = Integer.parseInt(br.readLine());
+
+        int[] dp = new int[n + 2];
+        int[] t = new int[n];
+        int[] p = new int[n];
+
+        for (int i = 0; i < n; i++) {
+            StringTokenizer st = new StringTokenizer(br.readLine());
+            t[i] = Integer.parseInt(st.nextToken());
+            p[i] = Integer.parseInt(st.nextToken());
+        }
+
+        for (int i = 0; i < n; i++) {
+            // 오늘 상담 안 하는 경우
+            dp[i + 1] = Math.max(dp[i + 1], dp[i]);
+
+            // i + t[i]일에 완료
+            if (i + t[i] <= n) {
+                dp[i + t[i]] = Math.max(dp[i + t[i]], dp[i] + p[i]);
+            }
+        }
+
+        // 최종 최대 이익
+        System.out.println(Math.max(dp[n], dp[n + 1]));
+    }
+}

--- a/src/main/java/org/example/week4/Algorithm9252.java
+++ b/src/main/java/org/example/week4/Algorithm9252.java
@@ -1,0 +1,46 @@
+package org.example.week4;
+
+import java.io.BufferedReader;
+import java.io.IOException;
+import java.io.InputStreamReader;
+
+public class Algorithm9252 {
+    public static void main(String[] args) throws IOException {
+        BufferedReader br = new BufferedReader(new InputStreamReader(System.in));
+        char[] a = br.readLine().toCharArray();
+        char[] b = br.readLine().toCharArray();
+        int n = a.length, m = b.length;
+
+        int[][] dp = new int[n + 1][m + 1];
+
+        // lcs 길이 채우기
+        for (int i = 1; i <= n; i++) {
+            for (int j = 1; j <= m; j++) {
+                if (a[i - 1] == b[j - 1]) {
+                    dp[i][j] = dp[i - 1][j - 1] + 1;
+                } else {
+                    dp[i][j] = Math.max(dp[i - 1][j], dp[i][j - 1]);
+                }
+            }
+        }
+
+        // 역추적으로 lcs 문자열 구하기
+        StringBuilder sb = new StringBuilder();
+        int i = n, j = m;
+        while (i > 0 && j > 0) {
+            if (a[i - 1] == b[j - 1]) {
+                sb.append(a[i - 1]);
+                i--; j--;
+            } else if (dp[i - 1][j] > dp[i][j - 1]) {
+                i--;
+            } else {
+                j--;
+            }
+        }
+
+        System.out.println(dp[n][m]);
+        if (dp[n][m] > 0) {
+            System.out.println(sb.reverse());
+        }
+    }
+}


### PR DESCRIPTION
## Algorithm11726 - **2×n 타일링**

### 1. 점화식 정의 및 귀납적 검증

- 상태 정의: `dp[n]` = `2 x n` 직사각형을 채우는 경우의 수
- 점화식:dp[n]=dp[n−1]+dp[n−2]
    
    dp[n]=dp[n−1]+dp[n−2]dp[n] = dp[n-1] + dp[n-2]
    

귀납적 설명

- 기저 사례
    - `dp[0] = 1`: 아무것도 안 놓는 것도 하나의 방법
    - `dp[1] = 1`: 세로로 `2×1` 하나만 놓을 수 있음
- 귀납 가정 : `dp[k-1]`, `dp[k-2]`가 올바르게 계산된다고 가정
- 귀납 증명 : `2×k` 타일은 두 가지 방식으로 끝남
    - 마지막에 `1×2` 타일을 세로로 → `2×(k-1)`이 남음 → `dp[k-1]`
    - 마지막에 `2×1` 타일 2개를 가로로 → `2×(k-2)`이 남음 → `dp[k-2]`
    
    따라서 귀납적으로 점화식이 유지
    
    <aside>
    
    dp[k]=dp[k−1]+dp[k−2]dp[k] = dp[k-1] + dp[k-2]
    
    dp[k]=dp[k−1]+dp[k−2]
    
    </aside>
    

### 2. 시간 / 공간 복잡도 분석

- 반복문은 `n-1`번 수행 → O(n)
- 각 연산은 상수 시간 → 총 시간 복잡도: O(n)
- 배열을 안 쓰고, `int`형 3개만 사용
- 공간 복잡도: O(1)

### 3. 비트 연산 최적화 (가능한 경우는?)

- 일반적으로 10007이 2의 제곱수라면 `% 1007`를 `& (1007 - 1)`로 대체할 수 있음
- 하지만 이 문제는 `10007` (소수)라서 비트 마스킹 최적화 불가능
    
    → 따라서 % 10007은 일반 덧셈 후 % 연산 유지 필요
    

## Algorithm15486 - **퇴사 2**

### 1. 문제 핵심 정리

- n일 동안 각 날짜별로 상담이 1개씩 있음
- 각 상담은 `(ti, pi)` → `ti`일이 소요되고 `pi`만큼 보상
- 한 번 시작한 상담은 연속된 `ti`일 동안 다른 상담 불가
- n+1일에 퇴사 → `i + ti > n`이면 상담 불가
- 최대 수익을 구해야 한다.

### 2. 알고리즘 전략: DP + 선형 스케줄링 (O(N))

> DP 상태 정의
> 
- `dp[i]` :  1일부터 i일까지 선택 가능한 상담의 최대 수익
- `i+ti <= N`인 경우: `i`일에 상담을 선택 → `dp[i + ti] = max(dp[i + ti], dp[i] + ti)`
- `i+ti > N`: 상담 불가능
- 오늘 상담을 안 하고 넘기는 경우의 최대 수익을 다음날로 이어주기 위해 `dp[i+1] = max(dp[i+1], dp[i])`

### 3. 시간 / 공간 복잡도 분석

- 시간 복잡도 O(N)
- 공간 복잡도 O(N)

### 4. 참고

📌 Segment Tree / Lazy Propagation?

- 상담 시간이 특정 범위에서 가장 높은 수익을 계산할 경우 사용 가능
- 하지만 이 문제는 단조적인 시간 순서 진행이므로 선형 DP가 훨씬 간단하고 빠름

📌 행렬 거듭제곱 / 그리디?

- 해당 문제는 피보나치, 반복 점화식이 아닌, 비정형 스케줄링 최적화 문제이므로 적용 불가

- 냐
    1. 큰 입력이니까 선형 알고리즘이 필요하고
    2. DP를 쓰지만메모리를 `O(N)` 이하로 줄이고 중간 상태만 유지
    3. 상담을 하고 안하고로 분기로 처리하여 누적 최대값 유지
    4. `dp[i] → dp[i+1], dp[i + t[i]]`로만 상태 전이되므로 불필요한 배열 접근 최소화

## Algorithm9252 - **LCS 2**

### 1. 문제 분석

- 문자열 길이 최대 1000 → 시간 제한 0.1초 → 절대 `O(n³)` 불가
- 부분 수열이므로 연속될 필요는 없지만 순서는 지켜야 함
- 단순히 길이뿐만 아니라 문자열도 복원
- 복원은 여러 가지 답이 있을 수 있지만 하나만 맞게 출력하면 됨
- 두 번째 줄은 길이가 0이면 출력 안 함

1. DP 테이블 정의

`dp[i][j] = 첫 번째 문자열의 i번째까지와, 두 번째 문자열의 j번째까지 비교했을 때의 LCS 길이`

인덱스를 문자열 길이로 맞춰서 `dp[0][*] = dp[*][0] = 0`

2. 점화식

문자가 같을 경우: `dp[i][j] = dp[i-1][j-1] + 1`

문자가 다르면: `dp[i][j] = max(dp[i-1][j], dp[i][j-1])`

이건 두 가지 경우 중 더 나은 LCS를 고르는 것

3. 문자열 복원

`dp[n][m]`은 전체 문자열의 LCS 길이

이걸 `dp` 테이블을 역으로 따라가며 문자들을 모은다

- `a[i-1] == b[j-1]` → 이 문자는 공통 문자 → 정답에 포함
- 다르면 → 더 큰 값을 향해 이동 (`dp[i-1][j]` 또는 `dp[i][j-1]`)

### 2.  알고리즘 전략 (DP + 역추적)

1. LCS 길이 계산

- `dp[i][j]`: A의 i번째 문자까지, B의 j번째 문자까지의 LCS 길이
    
    <aside>
    
    `dp[i][j] = dp[i-1][j-1] + 1` if `A[i-1] == B[j-1]`
    
    `dp[i][j] = max(dp[i-1][j], dp[i][j-1])` otherwise
    
    </aside>
    

2. LCS 문자열 복원

- `dp` 테이블을 역방향으로 따라가면서 문자 추가
- 선택의 경로가 `dp[i][j] == dp[i-1][j-1] + 1`이면 `A[i-1]`이 LCS에 포함됨

---

### 3. 시간/공간 최적화 전략

- 시간 복잡도: `O(n * m)`
- 공간 복잡도: `O(n * m)`
    - 문자열 복원 때문에 full DP 테이블 필요