### PR TITLE
4주차 알고리즘 문제 풀이

### DIFF
--- a/src/main/java/org/example/BOJ11722.java
+++ b/src/main/java/org/example/BOJ11722.java
@@ -1,0 +1,31 @@
+package org.example;
+
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class BOJ11722 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+
+		int[] numbers = new int[n];
+		int[] dp = new int[n];
+		int max = 0;
+
+		for (int i = 0; i < n; i++) {
+			numbers[i] = sc.nextInt();
+		}
+
+		Arrays.fill(dp, 1);
+
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < i; j++) {
+				if (numbers[i] < numbers[j]) {
+					dp[i] = Math.max(dp[i], dp[j] + 1);
+				}
+			}
+			max = Math.max(max, dp[i]);
+		}
+		System.out.println(max);
+	}
+}

--- a/src/main/java/org/example/BOJ11726.java
+++ b/src/main/java/org/example/BOJ11726.java
@@ -1,0 +1,27 @@
+package org.example;
+
+import java.util.Scanner;
+
+public class BOJ11726 {
+	static long[] dp;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+
+		if (n == 1) {
+			System.out.println(1);
+			return;
+		}
+
+		dp = new long[n + 1];
+
+		dp[1] = 1;
+		dp[2] = 2;
+		for (int i = 3; i <= n; i++) {
+			dp[i] = (dp[i - 1] + dp[i - 2]) % 10007;
+		}
+
+		System.out.println(dp[n]);
+	}
+}

--- a/src/main/java/org/example/BOJ1463.java
+++ b/src/main/java/org/example/BOJ1463.java
@@ -1,0 +1,30 @@
+package org.example;
+
+import java.util.Scanner;
+
+public class BOJ1463 {
+	static int[] dp;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+
+		int x = sc.nextInt();
+
+		dp = new int[x + 1];
+
+		dp[1] = 0;
+
+		// 각 인덱스마다 모든 연산을 수 행 후에 값을 비교하여 최소의 경우를 대입
+		for (int i = 2; i <= x; i++) {
+			dp[i] = dp[i - 1] + 1;
+
+			if (i % 2 == 0) {
+				dp[i] = Math.min(dp[i], dp[i / 2] + 1);
+			}
+			if (i % 3 == 0) {
+				dp[i] = Math.min(dp[i], dp[i / 3] + 1);
+			}
+		}
+		System.out.println(dp[x]);
+	}
+}

--- a/src/main/java/org/example/BOJ1520.java
+++ b/src/main/java/org/example/BOJ1520.java
@@ -1,0 +1,60 @@
+package org.example;
+
+import java.util.Scanner;
+
+public class BOJ1520 {
+	static int[] dx = {-1, 0, 1, 0};
+	static int[] dy = {0, 1, 0, -1};
+	static int[][] map, dp;
+	static int n, m;
+
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		n = sc.nextInt();
+		m = sc.nextInt();
+
+		map = new int[n][m];
+		dp = new int[n][m];
+
+		// 갔던 경로를 0, 목적지 도달 시 재귀가 풀리며 1씩 카운트하기 위해 -1로 초기화
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < m; j++) {
+				map[i][j] = sc.nextInt();
+				dp[i][j] = -1;
+			}
+		}
+
+		System.out.println(dfs(0, 0));
+	}
+
+	static int dfs(int x, int y) {
+		// 목적지에 도착하면 1을 반환 -> 재귀가 return을 통해 현재 경로에 1을 다 반환
+		if (x == m - 1 && y == n - 1) {
+			return 1;
+		}
+
+		// 이미 갔던 경로이면 카운트된 값을 반환
+		if(dp[y][x] != -1){
+			return dp[y][x];
+		}
+
+		// 새로운 경로이면 0으로 초기화 -> 도착지에 도착하면 1이 반환되어 1씩 커짐
+		dp[y][x] = 0;
+
+		for (int i = 0; i < 4; i++) {
+			int nextX = x + dx[i];
+			int nextY = y + dy[i];
+
+			if (nextX >= 0
+					&& nextX < m
+					&& nextY >= 0
+					&& nextY < n
+					&& map[nextY][nextX] < map[y][x]) {
+				// 현재 경로의 카운트 값에 새로운 경로의 탐색 결과를 누적
+				dp[y][x] += dfs(nextX, nextY);
+			}
+		}
+		// 재귀 풀릴 때 출발점에 경로 카운트 결과가 누적되어 반환됨
+		return dp[y][x];
+	}
+}

--- a/src/main/java/org/example/BOJ15486.java
+++ b/src/main/java/org/example/BOJ15486.java
@@ -1,0 +1,32 @@
+package org.example;
+
+import java.util.Scanner;
+
+public class BOJ15486 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+
+		// 인덱스 맞추기용 +1, 퇴사 날짜까지 카운트 +1
+		int[] t = new int[n + 2];
+		int[] p = new int[n + 2];
+		int[] dp = new int[n + 2];
+
+		for (int i = 1; i <= n; i++) {
+			t[i] = sc.nextInt();
+			p[i] = sc.nextInt();
+		}
+
+		for (int i = 1; i <= n + 1; i++) {
+			// 상담을 안 한 경우 이전 날짜의 수익을 가져와서 비교 후 대입
+			dp[i] = Math.max(dp[i], dp[i - 1]);
+
+			// 상담을 하는 경우 상담 종료일에 추가된 수익과 기존 수익을 비교하여 대입
+			if (i + t[i] <= n + 1) {
+				dp[i + t[i]] = Math.max(dp[i + t[i]], dp[i] + p[i]);
+			}
+		}
+
+		System.out.println(dp[n + 1]);
+	}
+}


### PR DESCRIPTION
## ✅ 2*n 타일링(11726)

### 🤔 문제 확인

타일로 채우는 과정에서의 규칙성을 찾아내고 점화식을 세워서 해결하는 문제로, 가로 타일은 무조건 나란히 위치해야함을 이용

### 📝 풀이 방법

타일을 배치 시키는 과정에서 2\*n크기의 직사각형을 채우는 방법은 수는 2\*(n-1)크기의 직사각형을 채우는 경우의 수에 세로타일 1개를 추가하는 경우와 2\*(n-2)크기의 직사각형을 채우는 경우의 수에 가로타일을 나란히 추가하는 경우이다.

따라서 점화식은 d[n] = d[n - 1] + d[n - 2]이며 일반적인 피보나치 수열과 동일하다.

---

## ✅ 1로 만들기(1463)

### 🤔 문제 확인

시간 제한 0.15초, 주어진 데이터의 크기가 1,000,000까지 이므로 시간복잡도 O(nlogn)까지 가능

연산의 우선 순위에따라 수행하는 것이 아니라 모든 연산을 수행한 후에 연산 횟수의 최솟값을 선택

### 📝 풀이 방법

모든 연산의 결과를 기록하고 최솟값을 선택하기 위해 메모이제이션을 이용

메모이제이션 배열의 인덱스를 연산과정에서 발생할 수 있는 모든 중간 결과들과 연결지어 연산의 횟수를 계산하고 기존 연산 횟수와 비교하여 최솟값으로 변경

연산이 모두 끝난 후에 인덱스 X에 존재하는 값이 1에 도달하기 위한 최소 연산 횟수

---

## ✅ 가장 긴 감소하는 부분 순열(11722)

### 🤔 문제 확인

시간 제한 1초, 주어진 수열의 크기가 1,000이하의 값이므로 시간복잡도 O(n^2)까지는 허용

### 📝 풀이 방법

입력받은 수열을 처음부터 순회하며 줄어드는 구간의 수를 카운트

카운트 결과와 기존 카운트 수를 비교하여 가장 큰 수를 저장하여 메모이제이션

순회가 모두 끝나고 메모이제이션 배열에서 가장 큰 카운트 횟수를 출력

---

## ✅ 퇴사2(15486)

### 🤔 문제 확인

시간 제한 2초, 주어진 데이터의 길이는 1,500,000 이므로 시간복잡도 O(nlogn)정도 까지만 허용

각 날짜마다 순회하기 위해 이중 반복문을 사용하면 시간초과 발생

### 풀이 방법

처음 상담부터 하나씩 순회하며 상담을 진행했을 경우와 하지 않았을 경우의 수입을 메모이제이션

연산 과정에서 기존 값과 새로 계산된 수입을 비교하여 최대값을 저장

순회가 종료되고 퇴사 당일에 해당하는 메모이제이션 배열의 가장 마지막 인덱스의 값이 상담 일정에서의 최대 수익



---

## ✅ 내리막 길(1520)

### 🤔 문제 확인

시간 제한 2초, 주어진 데이터의 길이는 500*500 이므로 일반적인 DFS로 풀면 시간초과 발생

DFS와 DP를 함깨 사용해야함

### 📝 풀이 방법

일반적인 DFS만 사용하면 경로 탐색 과정에서 중복되는 경로를 탐색하게 되므로 메모이제이션을 통해 중복되는 경로의 탐색을 방지

DFS를 통해 목적지까지의 탐색이 완료되면 해당 경로에 해당하는 메모이제이션 배열에 1을 더하기 → 각 지점별로 목적지까지 갈 수 있는 경우의 수가 저장됨

재귀 호출이 종료되면 지점별로 카운트된 횟수들이 반환, 누적되어 시작점에 최종적으로 이동 가능한 경로의 수가 저장됨