### PR TITLE
5주차 알고리즘 문제 풀이

### DIFF
--- a/src/main/java/org/example/BOJ10844.java
+++ b/src/main/java/org/example/BOJ10844.java
@@ -1,0 +1,35 @@
+package org.example;
+
+import java.util.Arrays;
+import java.util.Scanner;
+
+public class BOJ10844 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		long[][] dp = new long[n + 1][10];
+
+		// n=1인 경우에 대한 초기화 진행
+		for (int i = 0; i <= 9; i++) {
+			dp[1][i] = 1;
+		}
+
+		for (int i = 2; i <= n; i++) {
+			// 0으로 시작하는 계단 수의 개수
+			dp[i][0] = dp[i - 1][1] % 1_000_000_000;
+			for (int j = 1; j <= 9; j++) {
+				if (j == 9) {
+					// 9로 시작하는 계단수의 개수
+					dp[i][j] = dp[i - 1][8] % 1_000_000_000;
+				} else {
+					dp[i][j] = (dp[i - 1][j - 1] + dp[i - 1][j + 1]) % 1_000_000_000;
+				}
+			}
+		}
+		long result = 0;
+		for (int i = 1; i <= 9; i++) {
+			result += dp[n][i];
+		}
+		System.out.println(result % 1_000_000_000);
+	}
+}

--- a/src/main/java/org/example/BOJ11052.java
+++ b/src/main/java/org/example/BOJ11052.java
@@ -1,0 +1,24 @@
+package org.example;
+
+import java.util.Scanner;
+
+public class BOJ11052 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+		int n = sc.nextInt();
+		int[] p = new int[n + 1];
+		int[] dp = new int[n + 1];
+
+		for (int i = 1; i <= n; i++) {
+			p[i] = sc.nextInt();
+		}
+
+		for (int i = 1; i <= n; i++) {
+			for (int j = 1; j <= i; j++) {
+				// 카드 구매 비용 메모이제이션
+				dp[i] = Math.max(dp[i], dp[i - j] + p[j]);
+			}
+		}
+		System.out.println(dp[n]);
+	}
+}

--- a/src/main/java/org/example/BOJ1890.java
+++ b/src/main/java/org/example/BOJ1890.java
@@ -1,0 +1,40 @@
+package org.example;
+
+import java.util.Scanner;
+
+public class BOJ1890 {
+	public static void main(String[] args) {
+		Scanner sc = new Scanner(System.in);
+
+		int n = sc.nextInt();
+		int[][] numbers = new int[n][n];
+		long[][] dp = new long[n][n];
+
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; j++) {
+				numbers[i][j] = sc.nextInt();
+			}
+		}
+
+		// 출발지점 초기화
+		dp[0][0] = 1;
+
+		for (int i = 0; i < n; i++) {
+			for (int j = 0; j < n; j++) {
+				int distance = numbers[i][j];
+				if (distance == 0) {
+					break;
+				}
+				// 아래로 점프하는 경우를 계산하고 저장
+				if (i + distance < n) {
+					dp[i + distance][j] += dp[i][j];
+				}
+				// 오른쪽으로 점프하는 경우를 계산하고 저장
+				if (j + distance < n) {
+					dp[i][j + distance] += dp[i][j];
+				}
+			}
+		}
+		System.out.println(dp[n - 1][n - 1]);
+	}
+}


### PR DESCRIPTION
## ✅ 점프(1890)

### 🤔 문제 확인

시간 제한 1초, 주어진 배열의 크기는 최대 100*100이므로 시간 복잡도 O(n^2)까지 허용

### 📝 풀이 방법

아래로 이동하는 경우와 오른쪽으로 이동하는 경우에 대한 점화식을 세우고, 각 칸마다 이동한 결과를 메모이제이션

각 칸에 해당하는 수 만큼 점프하게 되기 때문에 현재 위치에서의 이동 횟수를 이동한 칸에 더해주는 연산을 진행

아래로 이동하는 경우의 점화식은 d[i + distance]\[j] = d[i]\[j], 오른쪽으로 이동하는 경우의 점화식은 d[i]\[j + distance] = d[i]\[j]

연산 과정에서 이미 지나온 경로에 대한 값이 누적되어 최종적으로 도착 지점에서의 값이 도달 가능한 경로의 수와 동일

---

## ✅ 카드 구매하기(11052)

### 🤔 문제 확인

시간 제한 1초, 주어진 데이터의 크기가 1,000까지 이므로 시간복잡도 O(n^2)까지 허용

### 📝 풀이 방법

모든 연산의 결과를 기록하고 최대값을 선택하기 위해 메모이제이션을 이용

카드 가격 배열을 순회하며 n개의 카드를 사기 위한 모든 경우의 수를 메모이제이션 배열의 결과를 이용하여 계산하고 최대값을 메모이제이션 배열에 저장

연산이 모두 끝난 후에 n번째 배열에서의 값이 n개의 카드를 구매하기 위한 최대 비용

---

## ✅ 쉬운 게단 수(11084)

### 🤔 문제 확인

시간 제한 1초, 주어진 계단수의 자릿수가 100, 숫자 범위가 1~9이므로 시간복잡도 O(n^2)까지 허용

### 📝 풀이 방법

길이가 i이고 j로 시작하는 계단수는 두 가지 방법으로 만들 수 있음

- 길이가 i-1이고 j-1로 시작하는 계단 수의 앞에 j를 추가하여 만드는 경우
- 길이가 i-1이고 j+1로 시작하는 계단 수의 앞에 j를 추가하여 만드는 경우

따라서 계단수의 길이와 계단 수를 시작하는 숫자에 대한 메모이제이션 배열을 2차원으로 설정, 1로 시작하는 계단 수의 경우도 구하기 위해 0으로 시작하는 계단 수의 고려도 필요

위의 경우의 수에 따라 점화식은 d[i]\[j] = d[i - 1]\[j - 1] + d[i - 1]\[j + 1], 이때 배열의 양 끝자리에 존재하는 0으로 시작하는 계단 수의 개수와 9로 시작하는 계단 수의 개수는 각 각 인접한 수로 시작하고 길이가 i-1인 계단 수의 수와 같음(길이가 하나 적은 계단 수에 9나 0을 붙여서 만들면 되기 때문)

따라서 최종적인 점화식은 아래와 같다.

- 2~8로 시작하는 계단 수의 개수: d[i]\[j] = d[i - 1]\[j - 1] + d[i - 1]\[j + 1]
- 0으로 시작하는 계단 수의 개수: d[i]\[0] = d[i - 1]\[1]
- 9로 시작하는 계단 수의  개수: d[i]\[9] = d[i - 1]\[8]

위의 점화식에 따라 계단 수를 모두 계산하고 길이가 i인 계단 수의 개수를 모두 더한 뒤 0으로 시작하는 경우의 수를 제외